### PR TITLE
Add run-time retrieval of cidrs to sshuttle runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,14 @@ $ git clone git@github.com:pivotal/hammer.git && cd hammer && go install
 In order to run the `hammer` tool against a given environment you need to have an environment config file in the following format:
 ```json
 {
-  "ert_cidr": "PAS-SUBNET-CIDR",
   "name": "ENVIRONMENT-NAME",
   "ops_manager": {
     "url": "OPSMAN-FQDN",
     "username": "OPSMAN-USERNAME",
     "password": "OPSMAN-PASSWORD"
   },
-  "ops_manager_cidr": "OPSMAN-SUBNET-CIDR",
   "ops_manager_private_key": "OPSMAN-RSA-PRIVATE-KEY",
   "ops_manager_public_ip": "OPSMAN-PUBLIC-IP",
-  "services_cidr": "SERVICES-SUBNET-CIDR",
   "sys_domain": "PAS-SYSTEM-DOMAIN"
 }
 ```

--- a/integration/fixtures/sshuttle_script.sh
+++ b/integration/fixtures/sshuttle_script.sh
@@ -53,4 +53,5 @@ ZLuM3MSg63owoj01309KLkd0K+jh50SRmAdYcMF2Rwp+pmCD1umxkowU+JAeWdYU
 " >"$ssh_key_path"
 trap 'rm -f ${ssh_key_path}' EXIT
 chmod 0600 "${ssh_key_path}"
-sshuttle --ssh-cmd "ssh -o IdentitiesOnly=yes -i ${ssh_key_path}" -r ubuntu@"35.225.148.133" 10.0.0.0/24 10.0.4.0/24 10.0.8.0/24
+cidrs="$(om -t https://pcf.manatee.cf-app.com -k -u pivotalcf -p fakePassword curl -s -p /api/v0/staged/director/networks | jq -r .networks[].subnets[].cidr | xargs echo)"
+sshuttle --ssh-cmd "ssh -o IdentitiesOnly=yes -i ${ssh_key_path}" -r ubuntu@"35.225.148.133" ${cidrs}

--- a/sshuttle/runner.go
+++ b/sshuttle/runner.go
@@ -12,12 +12,19 @@ type Runner struct {
 }
 
 func (b Runner) Run(data environment.Config, dryRun bool, args ...string) error {
+	networksPath := "/api/v0/staged/director/networks"
+	cidrPath := ".networks[].subnets[].cidr"
+
 	sshuttleCommandLines := []string{
 		fmt.Sprintf(`ssh_key_path=$(mktemp)`),
 		fmt.Sprintf(`echo "%s" >"$ssh_key_path"`, data.OpsManager.PrivateKey),
 		fmt.Sprintf(`trap 'rm -f ${ssh_key_path}' EXIT`),
 		fmt.Sprintf(`chmod 0600 "${ssh_key_path}"`),
-		fmt.Sprintf(`sshuttle --ssh-cmd "ssh -o IdentitiesOnly=yes -i ${ssh_key_path}" -r ubuntu@"%s" %s %s %s`, data.OpsManager.IP.String(), data.OpsManager.CIDR.String(), data.PasCIDR.String(), data.ServicesCIDR.String()),
+		fmt.Sprintf(`cidrs="$(om -t %s -k -u %s -p %s curl -s -p %s | jq -r %s | xargs echo)"`,
+			data.OpsManager.URL.String(), data.OpsManager.Username, data.OpsManager.Password, networksPath, cidrPath),
+
+		fmt.Sprintf(`sshuttle --ssh-cmd "ssh -o IdentitiesOnly=yes -i ${ssh_key_path}" -r ubuntu@"%s" ${cidrs}`,
+			data.OpsManager.IP.String()),
 	}
 
 	return b.ScriptRunner.RunScript(sshuttleCommandLines, []string{"jq", "om", "sshuttle"}, dryRun)


### PR DESCRIPTION
This removes the need to specify cidrs in the environment config and
also allows the tool to work with environments with more or less than 3
subnets.

Potential downsides:
* If the config already had the CIDRs as they can currently be specified then this way is slower.
* This is based on retrieving the CIDRs from staged network properties which are not necessarily the same as the deployed properties. However these are properties which are not likely to change frequently after the initial install.