### PR TITLE
When no args passed to bosh command does not set bosh as a prereq

### DIFF
--- a/bosh/runner.go
+++ b/bosh/runner.go
@@ -33,6 +33,8 @@ func (r Runner) Run(data environment.Config, dryRun bool, boshArgs ...string) er
 		fmt.Sprintf(`bosh_proxy="BOSH_ALL_PROXY=ssh+socks5://ubuntu@%s:22?private-key=${ssh_key_path}"`, data.OpsManager.IP.String()),
 	}
 
+	prereqs := []string{"jq", "om", "ssh"}
+
 	if len(boshArgs) > 0 {
 		lines = append(
 			lines,
@@ -40,6 +42,7 @@ func (r Runner) Run(data environment.Config, dryRun bool, boshArgs ...string) er
 			fmt.Sprintf(`trap 'rm -f ${bosh_ca_path}' EXIT`),
 			fmt.Sprintf(`/usr/bin/env $bosh_client $bosh_env $bosh_secret $bosh_ca_cert $bosh_proxy bosh %s`, strings.Join(boshArgs, " ")),
 		)
+		prereqs = append(prereqs, "bosh")
 	} else {
 		lines = append(
 			lines,
@@ -57,5 +60,5 @@ func (r Runner) Run(data environment.Config, dryRun bool, boshArgs ...string) er
 		)
 	}
 
-	return r.ScriptRunner.RunScript(lines, []string{"jq", "om", "ssh", "bosh"}, dryRun)
+	return r.ScriptRunner.RunScript(lines, prereqs, dryRun)
 }

--- a/bosh/runner_test.go
+++ b/bosh/runner_test.go
@@ -37,6 +37,7 @@ var _ = Describe("bosh runner", func() {
 				Password:   "password",
 			},
 		}
+		boshArgs = []string{}
 
 		boshRunner = bosh.Runner{
 			ScriptRunner: scriptRunner,
@@ -48,10 +49,6 @@ var _ = Describe("bosh runner", func() {
 	})
 
 	When("no bosh args are passed to the bosh runner", func() {
-		BeforeEach(func() {
-			boshArgs = []string{}
-		})
-
 		It("runs the script with a series of bosh env var echos", func() {
 			Expect(scriptRunner.RunScriptCallCount()).To(Equal(1))
 
@@ -89,6 +86,15 @@ var _ = Describe("bosh runner", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 		})
+
+		It("specifies the appropriate prerequisites when running the script", func() {
+			Expect(scriptRunner.RunScriptCallCount()).To(Equal(1))
+
+			_, prereqs, _ := scriptRunner.RunScriptArgsForCall(0)
+
+			Expect(prereqs).To(ConsistOf("jq", "om", "ssh"))
+		})
+
 	})
 
 	When("one or more bosh args are passed to the bosh runner", func() {
@@ -126,14 +132,15 @@ var _ = Describe("bosh runner", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 		})
-	})
 
-	It("specifies the appropriate prerequisites when running the script", func() {
-		Expect(scriptRunner.RunScriptCallCount()).To(Equal(1))
+		It("specifies the appropriate prerequisites when running the script", func() {
+			Expect(scriptRunner.RunScriptCallCount()).To(Equal(1))
 
-		_, prereqs, _ := scriptRunner.RunScriptArgsForCall(0)
+			_, prereqs, _ := scriptRunner.RunScriptArgsForCall(0)
 
-		Expect(prereqs).To(ConsistOf("jq", "om", "ssh", "bosh"))
+			Expect(prereqs).To(ConsistOf("jq", "om", "ssh", "bosh"))
+		})
+
 	})
 
 	When("run with dry run set to false", func() {


### PR DESCRIPTION
When `hammer bosh` is run with no args for bosh then it is not actually going to run `bosh` so should not require it to be present.