### PR TITLE
Remove parsing CIDR from environment config

### DIFF
--- a/environment/config.go
+++ b/environment/config.go
@@ -25,7 +25,6 @@ type OpsManager struct {
 	Password   string
 	URL        url.URL
 	IP         net.IP
-	CIDR       net.IPNet
 	PrivateKey string
 }
 
@@ -35,9 +34,7 @@ type Config struct {
 	CFDomain      string
 	AppsDomain    string
 	OpsManager    OpsManager
-	PasCIDR       net.IPNet
 	PasSubnet     string
-	ServicesCIDR  net.IPNet
 	ServiceSubnet string
 	AZs           []string
 }
@@ -49,10 +46,7 @@ type environmentReader struct {
 	AppsDomain    string   `json:"apps_domain"`
 	PrivateKey    string   `json:"ops_manager_private_key"`
 	IP            string   `json:"ops_manager_public_ip"`
-	OpsManCIDR    string   `json:"ops_manager_cidr"`
-	PasCIDR       string   `json:"ert_cidr"`
 	PasSubnet     string   `json:"ert_subnet"`
-	ServicesCIDR  string   `json:"services_cidr"`
 	ServiceSubnet string   `json:"service_subnet_name"`
 	AZs           []string `json:"azs"`
 	OpsManager    struct {
@@ -98,38 +92,12 @@ func newLockfile(data environmentReader) (Config, error) {
 		return Config{}, fmt.Errorf("Could not parse IP address: %s", data.IP)
 	}
 
-	opsManCIDR := &net.IPNet{}
-	if data.OpsManCIDR != "" {
-		_, opsManCIDR, err = net.ParseCIDR(data.OpsManCIDR)
-		if err != nil {
-			return Config{}, err
-		}
-	}
-
-	pasCIDR := &net.IPNet{}
-	if data.OpsManCIDR != "" {
-		_, pasCIDR, err = net.ParseCIDR(data.PasCIDR)
-		if err != nil {
-			return Config{}, err
-		}
-	}
-
-	servicesCIDR := &net.IPNet{}
-	if data.OpsManCIDR != "" {
-		_, servicesCIDR, err = net.ParseCIDR(data.ServicesCIDR)
-		if err != nil {
-			return Config{}, err
-		}
-	}
-
 	return Config{
 		Name:          data.Name,
 		Version:       *parsedVersion,
 		CFDomain:      data.SysDomain,
 		AppsDomain:    data.AppsDomain,
-		PasCIDR:       *pasCIDR,
 		PasSubnet:     data.PasSubnet,
-		ServicesCIDR:  *servicesCIDR,
 		ServiceSubnet: data.ServiceSubnet,
 		AZs:           data.AZs,
 		OpsManager: OpsManager{
@@ -137,7 +105,6 @@ func newLockfile(data environmentReader) (Config, error) {
 			Password:   data.OpsManager.Password,
 			URL:        *parsedURL,
 			IP:         ip,
-			CIDR:       *opsManCIDR,
 			PrivateKey: data.PrivateKey,
 		},
 	}, nil

--- a/environment/config_test.go
+++ b/environment/config_test.go
@@ -54,23 +54,13 @@ func mustParseURL(u string) url.URL {
 	return *url
 }
 
-func mustParseCIDR(c string) net.IPNet {
-	_, cidr, err := net.ParseCIDR(c)
-	if err != nil {
-		panic(err)
-	}
-	return *cidr
-}
-
 func checkMatchLemon(e Config) {
 	Expect(e).To(MatchAllFields(Fields{
 		"Name":          Equal("lemon"),
 		"Version":       Equal(*version.Must(version.NewVersion("1.11"))),
 		"CFDomain":      Equal("sys.lemon.cf-app.com"),
 		"AppsDomain":    Equal("apps.lemon.cf-app.com"),
-		"PasCIDR":       Equal(mustParseCIDR("10.0.4.0/24")),
 		"PasSubnet":     Equal("lemon-pas-subnet"),
-		"ServicesCIDR":  Equal(mustParseCIDR("10.0.8.0/24")),
 		"ServiceSubnet": Equal("lemon-services-subnet"),
 		"AZs":           Equal([]string{"us-central1-f", "us-central1-a", "us-central1-c"}),
 		"OpsManager": MatchAllFields(Fields{
@@ -78,7 +68,6 @@ func checkMatchLemon(e Config) {
 			"Password":   Equal("fakePassword"),
 			"URL":        Equal(mustParseURL("https://pcf.lemon.cf-app.com")),
 			"IP":         Equal(net.ParseIP("35.225.148.133")),
-			"CIDR":       Equal(mustParseCIDR("10.0.0.0/24")),
 			"PrivateKey": ContainSubstring("BEGIN RSA"),
 		}),
 	}))


### PR DESCRIPTION
No longer needed with run time CIDR retrieval.

This also removes a bug with the CIDR parsing where the OpsManCIDR was being non-empty checked before attempting to parse PasCIDR or ServicesCIDR rather than the appropriate var.