### PR TITLE
Use configured opsman ssh username instead of hardcoded ubuntu

### DIFF
--- a/ssh/director_runner.go
+++ b/ssh/director_runner.go
@@ -53,7 +53,7 @@ func (b DirectorRunner) Run(data environment.Config, dryRun bool, args ...string
 
 		`trap 'rm -f ${director_ssh_key_path}; rm -f ${ssh_key_path}' EXIT`,
 
-		fmt.Sprintf(`jumpbox_cmd="ubuntu@%s -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -i ${ssh_key_path}"`, data.OpsManager.IP.String()),
+		fmt.Sprintf(`jumpbox_cmd="%s@%s -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -i ${ssh_key_path}"`, data.OpsManager.SshUser, data.OpsManager.IP.String()),
 		`ssh -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -J "$jumpbox_cmd" "bbr@${bosh_env}" -i "$director_ssh_key_path"`,
 	}
 

--- a/ssh/director_runner_test.go
+++ b/ssh/director_runner_test.go
@@ -39,6 +39,7 @@ var _ = Describe("director ssh runner", func() {
 		url, _ := url.Parse("https://www.test-url.io")
 		data = environment.Config{
 			OpsManager: environment.OpsManager{
+				SshUser:      "ssh_user",
 				PrivateKey:   "private-key-contents",
 				IP:           net.ParseIP("10.0.0.6"),
 				URL:          *url,
@@ -72,7 +73,7 @@ var _ = Describe("director ssh runner", func() {
 			`chmod 0600 "${director_ssh_key_path}"`,
 			`bosh_env="$(OM_CLIENT_ID='client_id' OM_CLIENT_SECRET='client_secret' OM_USERNAME='username' OM_PASSWORD='password' om -t https://www.test-url.io -k curl -s -p /api/v0/deployed/director/credentials/bosh_commandline_credentials | grep -o "BOSH_ENVIRONMENT=\S*" | cut -f2 -d=)"`,
 			`trap 'rm -f ${director_ssh_key_path}; rm -f ${ssh_key_path}' EXIT`,
-			`jumpbox_cmd="ubuntu@10.0.0.6 -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -i ${ssh_key_path}"`,
+			`jumpbox_cmd="ssh_user@10.0.0.6 -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -i ${ssh_key_path}"`,
 			`ssh -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -J "$jumpbox_cmd" "bbr@${bosh_env}" -i "$director_ssh_key_path"`,
 		}))
 	})

--- a/ssh/opsmanager_runner.go
+++ b/ssh/opsmanager_runner.go
@@ -22,7 +22,7 @@ type OpsManagerRunner struct {
 }
 
 func (b OpsManagerRunner) Run(data environment.Config, dryRun bool, args ...string) error {
-	sshCommand := fmt.Sprintf(`ssh -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -i "${ssh_key_path}" -t ubuntu@"%s"`, data.OpsManager.IP.String())
+	sshCommand := fmt.Sprintf(`ssh -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -i "${ssh_key_path}" -t %s@"%s"`, data.OpsManager.SshUser, data.OpsManager.IP.String())
 
 	sshCommandLines := []string{
 		`ssh_key_path=$(mktemp)`,

--- a/ssh/opsmanager_runner_test.go
+++ b/ssh/opsmanager_runner_test.go
@@ -39,6 +39,7 @@ var _ = Describe("ops manager ssh runner", func() {
 		url, _ := url.Parse("https://www.test-url.io")
 		data = environment.Config{
 			OpsManager: environment.OpsManager{
+				SshUser:      "ssh_user",
 				PrivateKey:   "private-key-contents",
 				IP:           net.ParseIP("10.0.0.6"),
 				URL:          *url,
@@ -71,7 +72,7 @@ var _ = Describe("ops manager ssh runner", func() {
 			`bosh="$(echo "$creds" | jq -r .credential | tr ' ' '\n' | grep '=')"`,
 			`echo "$bosh"`,
 			`shell="/usr/bin/env $(echo "$bosh" | tr '\n' ' ') bash -l"`,
-			`ssh -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -i "${ssh_key_path}" -t ubuntu@"10.0.0.6" "$shell"`,
+			`ssh -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -i "${ssh_key_path}" -t ssh_user@"10.0.0.6" "$shell"`,
 		}))
 	})
 


### PR DESCRIPTION
Found this issue trying to use hammer with my environment that expects a different username than `ubuntu`