### PR TITLE
README: call out explicitly that hammer has cli requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Alternatively you can build `hammer` from source if you have Go installed:
 git clone git@github.com:pivotal/hammer.git && cd hammer && go install
 ```
 
+You will also need to install, separately, any of the underlying cli tools that `hammer` will use in your workflow. `hammer` does not include `cf`, `bosh`, `om`, etc.
+
 ## Config
 
 In order to run the `hammer` tool against a given environment you need to have an environment config file in the following format:


### PR DESCRIPTION
This PR calls out, in the `Installation` section of the README, the fact that simply downloading hammer doesn't mean a user doesn't need to install other tools as well.

This might be implied, or even generally understood, from the description of the tool as a wrapper, but I'm confident a non-trivial proportion of users won't pick up on this, and will have a poor initial experience.