### PR TITLE
Remove comment outputs with command name

### DIFF
--- a/commands/bosh.go
+++ b/commands/bosh.go
@@ -25,6 +25,5 @@ func (c *BoshCommand) Execute(args []string) error {
 		return err
 	}
 
-	c.UI.DisplayText("# bosh\n")
 	return c.BoshRunner.Run(data, c.File, args...)
 }

--- a/commands/bosh_test.go
+++ b/commands/bosh_test.go
@@ -68,11 +68,6 @@ var _ = Describe("Bosh command", func() {
 			envReader.ReadReturns(environment.Config{Name: "env-name"}, nil)
 		})
 
-		It("displays bosh as a comment", func() {
-			Expect(ui.DisplayTextCallCount()).To(Equal(1))
-			Expect(ui.DisplayTextArgsForCall(0)).To(Equal("# bosh\n"))
-		})
-
 		It("runs the bosh tool using the retrieved environment config", func() {
 			Expect(boshRunner.RunCallCount()).To(Equal(1))
 

--- a/commands/cf_login.go
+++ b/commands/cf_login.go
@@ -29,7 +29,6 @@ func (c *CFLoginCommand) Execute(args []string) error {
 		return err
 	}
 
-	c.UI.DisplayText("# cf-login\n")
 	c.UI.DisplayText(fmt.Sprintf("Logging in to CF at: %s\n", data.OpsManager.URL.String()))
 
 	return c.CFLoginRunner.Run(data, c.File)

--- a/commands/cf_login_test.go
+++ b/commands/cf_login_test.go
@@ -72,9 +72,8 @@ var _ = Describe("cf login command", func() {
 		})
 
 		It("displays that the cf is being logged into", func() {
-			Expect(ui.DisplayTextCallCount()).To(Equal(2))
-			Expect(ui.DisplayTextArgsForCall(0)).To(Equal("# cf-login\n"))
-			Expect(ui.DisplayTextArgsForCall(1)).To(Equal("Logging in to CF at: www.test-cf.io\n"))
+			Expect(ui.DisplayTextCallCount()).To(Equal(1))
+			Expect(ui.DisplayTextArgsForCall(0)).To(Equal("Logging in to CF at: www.test-cf.io\n"))
 		})
 
 		It("runs the cf login tool using the retrieved environment config", func() {

--- a/commands/om.go
+++ b/commands/om.go
@@ -25,6 +25,5 @@ func (c *OMCommand) Execute(args []string) error {
 		return err
 	}
 
-	c.UI.DisplayText("# om\n")
 	return c.OMRunner.Run(data, c.File, args...)
 }

--- a/commands/om_test.go
+++ b/commands/om_test.go
@@ -69,11 +69,6 @@ var _ = Describe("om command", func() {
 			envReader.ReadReturns(environment.Config{Name: "env-name"}, nil)
 		})
 
-		It("displays om as a comment", func() {
-			Expect(ui.DisplayTextCallCount()).To(Equal(1))
-			Expect(ui.DisplayTextArgsForCall(0)).To(Equal("# om\n"))
-		})
-
 		It("runs the om tool using the retrieved environment config", func() {
 			Expect(omRunner.RunCallCount()).To(Equal(1))
 

--- a/commands/open.go
+++ b/commands/open.go
@@ -30,7 +30,6 @@ func (c *OpenCommand) Execute(args []string) error {
 		return err
 	}
 
-	c.UI.DisplayText("# open\n")
 	if c.Show {
 		c.UI.DisplayText(fmt.Sprintf("%s\n", data.OpsManager.URL.String()))
 		if data.OpsManager.ClientID != "" {

--- a/commands/open_test.go
+++ b/commands/open_test.go
@@ -77,11 +77,10 @@ var _ = Describe("open command", func() {
 		})
 
 		It("prints out that it is opening the ops manager and details on username and password", func() {
-			Expect(ui.DisplayTextCallCount()).To(Equal(4))
-			Expect(ui.DisplayTextArgsForCall(0)).To(Equal("# open\n"))
-			Expect(ui.DisplayTextArgsForCall(1)).To(Equal("Opening: www.test-cf.io\n"))
-			Expect(ui.DisplayTextArgsForCall(2)).To(Equal("Username is: test-username\n"))
-			Expect(ui.DisplayTextArgsForCall(3)).To(Equal("Password is in the clipboard\n"))
+			Expect(ui.DisplayTextCallCount()).To(Equal(3))
+			Expect(ui.DisplayTextArgsForCall(0)).To(Equal("Opening: www.test-cf.io\n"))
+			Expect(ui.DisplayTextArgsForCall(1)).To(Equal("Username is: test-username\n"))
+			Expect(ui.DisplayTextArgsForCall(2)).To(Equal("Password is in the clipboard\n"))
 		})
 
 		It("runs the open tool using the retrieved environment config", func() {
@@ -158,11 +157,10 @@ var _ = Describe("open command", func() {
 			})
 
 			It("prints out the url, username and password for the ops manager", func() {
-				Expect(ui.DisplayTextCallCount()).To(Equal(4))
-				Expect(ui.DisplayTextArgsForCall(0)).To(Equal("# open\n"))
-				Expect(ui.DisplayTextArgsForCall(1)).To(Equal("www.test-cf.io\n"))
-				Expect(ui.DisplayTextArgsForCall(2)).To(Equal("username: test-username\n"))
-				Expect(ui.DisplayTextArgsForCall(3)).To(Equal("password: test-password\n"))
+				Expect(ui.DisplayTextCallCount()).To(Equal(3))
+				Expect(ui.DisplayTextArgsForCall(0)).To(Equal("www.test-cf.io\n"))
+				Expect(ui.DisplayTextArgsForCall(1)).To(Equal("username: test-username\n"))
+				Expect(ui.DisplayTextArgsForCall(2)).To(Equal("password: test-password\n"))
 			})
 		})
 
@@ -180,11 +178,10 @@ var _ = Describe("open command", func() {
 			})
 
 			It("prints out that it is opening the ops manager and details on client id and client secret", func() {
-				Expect(ui.DisplayTextCallCount()).To(Equal(4))
-				Expect(ui.DisplayTextArgsForCall(0)).To(Equal("# open\n"))
-				Expect(ui.DisplayTextArgsForCall(1)).To(Equal("Opening: www.test-cf.io\n"))
-				Expect(ui.DisplayTextArgsForCall(2)).To(Equal("Client ID is: test-client-id\n"))
-				Expect(ui.DisplayTextArgsForCall(3)).To(Equal("Client Secret is in the clipboard\n"))
+				Expect(ui.DisplayTextCallCount()).To(Equal(3))
+				Expect(ui.DisplayTextArgsForCall(0)).To(Equal("Opening: www.test-cf.io\n"))
+				Expect(ui.DisplayTextArgsForCall(1)).To(Equal("Client ID is: test-client-id\n"))
+				Expect(ui.DisplayTextArgsForCall(2)).To(Equal("Client Secret is in the clipboard\n"))
 			})
 
 			When("running in show mode", func() {
@@ -193,11 +190,10 @@ var _ = Describe("open command", func() {
 				})
 
 				It("prints out the url, client id and client secret for the ops manager", func() {
-					Expect(ui.DisplayTextCallCount()).To(Equal(4))
-					Expect(ui.DisplayTextArgsForCall(0)).To(Equal("# open\n"))
-					Expect(ui.DisplayTextArgsForCall(1)).To(Equal("www.test-cf.io\n"))
-					Expect(ui.DisplayTextArgsForCall(2)).To(Equal("client id: test-client-id\n"))
-					Expect(ui.DisplayTextArgsForCall(3)).To(Equal("client secret: test-client-secret\n"))
+					Expect(ui.DisplayTextCallCount()).To(Equal(3))
+					Expect(ui.DisplayTextArgsForCall(0)).To(Equal("www.test-cf.io\n"))
+					Expect(ui.DisplayTextArgsForCall(1)).To(Equal("client id: test-client-id\n"))
+					Expect(ui.DisplayTextArgsForCall(2)).To(Equal("client secret: test-client-secret\n"))
 				})
 			})
 		})

--- a/commands/pks_login.go
+++ b/commands/pks_login.go
@@ -29,7 +29,6 @@ func (c *PKSLoginCommand) Execute(args []string) error {
 		return err
 	}
 
-	c.UI.DisplayText("# pks-login\n")
 	c.UI.DisplayText(fmt.Sprintf("Logging in to PKS at: %s\n", data.OpsManager.URL.String()))
 
 	return c.PKSLoginRunner.Run(data, c.File)

--- a/commands/pks_login_test.go
+++ b/commands/pks_login_test.go
@@ -72,9 +72,8 @@ var _ = Describe("pks login command", func() {
 		})
 
 		It("displays that the pks is being logged into", func() {
-			Expect(ui.DisplayTextCallCount()).To(Equal(2))
-			Expect(ui.DisplayTextArgsForCall(0)).To(Equal("# pks-login\n"))
-			Expect(ui.DisplayTextArgsForCall(1)).To(Equal("Logging in to PKS at: www.test-pks.io\n"))
+			Expect(ui.DisplayTextCallCount()).To(Equal(1))
+			Expect(ui.DisplayTextArgsForCall(0)).To(Equal("Logging in to PKS at: www.test-pks.io\n"))
 		})
 
 		It("runs the pks login tool using the retrieved environment config", func() {

--- a/commands/ssh.go
+++ b/commands/ssh.go
@@ -44,7 +44,6 @@ func (c *SSHDirectorCommand) Execute(args []string) error {
 		return err
 	}
 
-	c.UI.DisplayText("# ssh-director\n")
 	c.UI.DisplayText(fmt.Sprintf("Connecting to: %s\n", data.Name))
 
 	return c.SSHRunner.Run(data, c.File)
@@ -65,7 +64,6 @@ func (c *SSHOpsManagerCommand) Execute(args []string) error {
 		return err
 	}
 
-	c.UI.DisplayText("# ssh-opsman\n")
 	c.UI.DisplayText(fmt.Sprintf("Connecting to: %s\n", data.Name))
 
 	return c.SSHRunner.Run(data, c.File)

--- a/commands/ssh_test.go
+++ b/commands/ssh_test.go
@@ -71,9 +71,8 @@ var _ = Describe("ssh command", func() {
 			})
 
 			It("displays that the connection is being started", func() {
-				Expect(ui.DisplayTextCallCount()).To(Equal(2))
-				Expect(ui.DisplayTextArgsForCall(0)).To(Equal("# ssh-opsman\n"))
-				Expect(ui.DisplayTextArgsForCall(1)).To(Equal("Connecting to: env-name\n"))
+				Expect(ui.DisplayTextCallCount()).To(Equal(1))
+				Expect(ui.DisplayTextArgsForCall(0)).To(Equal("Connecting to: env-name\n"))
 			})
 
 			It("runs the ssh tool using the retrieved environment config", func() {
@@ -187,9 +186,8 @@ var _ = Describe("ssh command", func() {
 			})
 
 			It("displays that the connection is being started", func() {
-				Expect(ui.DisplayTextCallCount()).To(Equal(2))
-				Expect(ui.DisplayTextArgsForCall(0)).To(Equal("# ssh-director\n"))
-				Expect(ui.DisplayTextArgsForCall(1)).To(Equal("Connecting to: env-name\n"))
+				Expect(ui.DisplayTextCallCount()).To(Equal(1))
+				Expect(ui.DisplayTextArgsForCall(0)).To(Equal("Connecting to: env-name\n"))
 			})
 
 			It("runs the ssh tool using the retrieved environment config", func() {

--- a/commands/sshuttle.go
+++ b/commands/sshuttle.go
@@ -25,6 +25,5 @@ func (c *SshuttleCommand) Execute(args []string) error {
 		return err
 	}
 
-	c.UI.DisplayText("# sshuttle\n")
 	return c.SshuttleRunner.Run(data, c.File)
 }

--- a/commands/sshuttle_test.go
+++ b/commands/sshuttle_test.go
@@ -69,11 +69,6 @@ var _ = Describe("sshuttle command", func() {
 			envReader.ReadReturns(environment.Config{Name: "env-name"}, nil)
 		})
 
-		It("displays sshuttle as a comment", func() {
-			Expect(ui.DisplayTextCallCount()).To(Equal(1))
-			Expect(ui.DisplayTextArgsForCall(0)).To(Equal("# sshuttle\n"))
-		})
-
 		It("runs the sshuttle tool using the retrieved environment config", func() {
 			Expect(sshuttleRunner.RunCallCount()).To(Equal(1))
 

--- a/integration/om_command_test.go
+++ b/integration/om_command_test.go
@@ -67,7 +67,7 @@ var _ = Describe("OM", func() {
 
 			Eventually(session).Should(Exit(0))
 			Eventually(string(session.Err.Contents())).Should(Equal(""))
-			Eventually(string(session.Out.Contents())).Should(Equal("# om\nexport OM_TARGET='https://pcf.manatee.cf-app.com'\nexport OM_CLIENT_ID='fakeClientID'\nexport OM_CLIENT_SECRET='fakeClientSecret'\nexport OM_USERNAME='pivotalcf'\nexport OM_PASSWORD='fakePassword'\n"))
+			Eventually(string(session.Out.Contents())).Should(Equal("export OM_TARGET='https://pcf.manatee.cf-app.com'\nexport OM_CLIENT_ID='fakeClientID'\nexport OM_CLIENT_SECRET='fakeClientSecret'\nexport OM_USERNAME='pivotalcf'\nexport OM_PASSWORD='fakePassword'\n"))
 		})
 	})
 })


### PR DESCRIPTION
These comment outputs were intended to be used as part of an integration that is no longer going to take place so it is easiest to just remove them.

Resolves #57 